### PR TITLE
Fix default value for BioStudies API URL

### DIFF
--- a/biostudiesclient/config.py
+++ b/biostudiesclient/config.py
@@ -4,7 +4,7 @@ import os
 
 
 def get_biostudies_base_url_from_env():
-    biostudies_api_url_dev = 'http://biostudy-bia.ebi.ac.uk:8788'
+    biostudies_api_url_dev = 'http://biostudy-dev:8788'
     return os.environ.get('BIOSTUDIES_API_URL', biostudies_api_url_dev)
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='biostudies-client',
-    version='0.1.3',
+    version='0.1.4',
     description="Python client library for wrapping and handling BioStudies REST API calls",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Changes:
- Changes Biostudies API URL to point to their test environment instead of their dev one