### PR TITLE
[dcp-557] Fix HTTP error response parsing

### DIFF
--- a/biostudiesclient/config.py
+++ b/biostudiesclient/config.py
@@ -4,7 +4,7 @@ import os
 
 
 def get_biostudies_base_url_from_env():
-    biostudies_api_url_dev = 'http://biostudy-dev:8788'
+    biostudies_api_url_dev = 'https://wwwdev.ebi.ac.uk/biostudies/submissions/api'
     return os.environ.get('BIOSTUDIES_API_URL', biostudies_api_url_dev)
 
 

--- a/biostudiesclient/response_utils.py
+++ b/biostudiesclient/response_utils.py
@@ -71,13 +71,13 @@ class ResponseUtils:
 
     @staticmethod
     def __get_error_message(response_json):
-        message = response_json["log"]["message"]
-        detailed_messages = response_json["log"]["subnodes"]
+        message = response_json.get("log", {}). get("message", '')
+        detailed_messages = response_json.get("log", {}).get("subnodes", '')
         if detailed_messages:
             for additional_message in detailed_messages:
-                message += " " + additional_message['message']
+                message += " " + additional_message.get('message', '')
         if not message:
-            message = response_json["message"]
+            message = response_json.get("message", '')
 
         return message
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 mock
 pylint
 nose
+assertpy
 -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='biostudies-client',
-    version='0.1.4',
+    version='0.1.5',
     description="Python client library for wrapping and handling BioStudies REST API calls",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/unit/test_response_utils.py
+++ b/tests/unit/test_response_utils.py
@@ -37,8 +37,8 @@ class TestResponseUtils(unittest.TestCase):
         assert_that(self.response_utils.handle_response)\
             .raises(RestErrorException)\
             .when_called_with(input_response)\
-            .starts_with('(\'Something')\
-            .is_equal_to('(\'Something went wrong.\', <HTTPStatus.REQUEST_TIMEOUT: 408>)')
+            .starts_with("('Something")\
+            .is_equal_to("('Something went wrong.', <HTTPStatus.REQUEST_TIMEOUT: 408>)")
 
     def test_when_processing_detailed_error_message_returns_parsed_message(self):
         input_response = Mock(spec=Response)
@@ -58,8 +58,8 @@ class TestResponseUtils(unittest.TestCase):
         assert_that(self.response_utils.handle_response) \
             .raises(RestErrorException) \
             .when_called_with(input_response) \
-            .starts_with('(\'A detailed') \
-            .is_equal_to('(\'A detailed error message\', <HTTPStatus.BAD_REQUEST: 400>)')
+            .starts_with("('A detailed") \
+            .is_equal_to("('A detailed error message', <HTTPStatus.BAD_REQUEST: 400>)")
 
     def correct_response_text_with_session_id(self):
         return {

--- a/tests/unit/test_response_utils.py
+++ b/tests/unit/test_response_utils.py
@@ -1,9 +1,12 @@
+import json
 import unittest
 from http import HTTPStatus
 from unittest.mock import Mock
 
+from assertpy import assert_that
 from requests import Response
 
+from biostudiesclient.exceptions import RestErrorException
 from biostudiesclient.response_utils import ResponseUtils
 
 
@@ -23,6 +26,40 @@ class TestResponseUtils(unittest.TestCase):
 
         self.assertEqual(output_response.status, HTTPStatus.OK)
         self.assertEqual(output_response.json, response_text)
+
+    def test_when_processing_plain_error_message_returns_parsed_message(self):
+        input_response = Mock(spec=Response)
+        input_response.status_code = HTTPStatus.REQUEST_TIMEOUT
+        error_message: str = '{"message":"Something went wrong."}'
+        input_response.json.return_value = json.loads(error_message)
+        input_response.text = error_message
+
+        assert_that(self.response_utils.handle_response)\
+            .raises(RestErrorException)\
+            .when_called_with(input_response)\
+            .starts_with('(\'Something')\
+            .is_equal_to('(\'Something went wrong.\', <HTTPStatus.REQUEST_TIMEOUT: 408>)')
+
+    def test_when_processing_detailed_error_message_returns_parsed_message(self):
+        input_response = Mock(spec=Response)
+        input_response.status_code = HTTPStatus.BAD_REQUEST
+        a_detailed_error_message = 'A detailed error message'
+        error_message: dict = {
+          "status": "FAIL",
+          "log": {
+            "level": "ERROR",
+            "message": a_detailed_error_message,
+            "subnodes": []
+          }
+        }
+        input_response.json.return_value = error_message
+        input_response.text = json.dumps(error_message)
+
+        assert_that(self.response_utils.handle_response) \
+            .raises(RestErrorException) \
+            .when_called_with(input_response) \
+            .starts_with('(\'A detailed') \
+            .is_equal_to('(\'A detailed error message\', <HTTPStatus.BAD_REQUEST: 400>)')
 
     def correct_response_text_with_session_id(self):
         return {


### PR DESCRIPTION
dcp-557

Changes:
- Fixes the parsing of the HTTP error response that comes from BioStudies service.